### PR TITLE
updating symfony/validator from 2.6 to 2.6.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php"                  : ">=5.3",
         "lib-curl"             : "*",
         "fliglio/http"         : "dev-master",
-        "symfony/validator"    : "2.6",
+        "symfony/validator"    : "2.6.*",
         "doctrine/annotations" : "1.*",
         "doctrine/cache"       : "1.*"
     },


### PR DESCRIPTION
tests pass, can't use symfony/validator 2.8.*