### PR TITLE
updating ValidationException and Entity validation error flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 composer.lock
 build
+.idea

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -41,11 +41,8 @@ class Entity {
 		$entity = $entityType::unmarshal($arr);
 
 		if ($entity instanceof Validation) {
-			try {
-				$entity->validate();
-			} catch (ValidationException $e) {
-				throw new BadRequestException($e->getMessage());
-			}
+			// throws ValidationException on constraint violation
+			$entity->validate();
 		}
 		return $entity;
 	}

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -2,8 +2,6 @@
 
 namespace Fliglio\Web;
 
-use Fliglio\Http\Exceptions\BadRequestException;
-
 class Entity {
 	private $body;
 	private $contentType;

--- a/src/ValidationException.php
+++ b/src/ValidationException.php
@@ -2,4 +2,22 @@
 
 namespace Fliglio\Web;
 
-class ValidationException extends \Exception {}
+use Fliglio\Http\Exceptions\BadRequestException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Throwable;
+
+class ValidationException extends BadRequestException {
+	/** @var ConstraintViolationListInterface */
+	private $constraintViolationList;
+	public function __construct(ConstraintViolationListInterface $constraintViolationList) {
+		parent::__construct($constraintViolationList);
+		$this->constraintViolationList = $constraintViolationList;
+	}
+
+	/**
+	 * @return ConstraintViolationListInterface
+	 */
+	public function getConstraintViolationList() {
+		return $this->constraintViolationList;
+	}
+}

--- a/test/Bar.php
+++ b/test/Bar.php
@@ -18,6 +18,13 @@ class Bar implements Validation, MappableApi {
 	private $name;
 
 	/**
+	 * @Assert\EqualTo(
+	 *     value = "bar"
+	 * )
+	 */
+	private $otherName;
+
+	/**
 	 * @Assert\Valid
 	 */
 	private $foo; // Foo
@@ -48,4 +55,22 @@ class Bar implements Validation, MappableApi {
 	public function getFoos() {
 		return $this->foos;
 	}
+
+	/**
+	 * @return mixed
+	 */
+	public function getOtherName() {
+		return $this->otherName;
+	}
+
+	/**
+	 * @param mixed $otherName
+	 * @return Bar
+	 */
+	public function setOtherName($otherName) {
+		$this->otherName = $otherName;
+		return $this;
+	}
+
+
 }

--- a/test/ValidationTraitTest.php
+++ b/test/ValidationTraitTest.php
@@ -90,4 +90,24 @@ class ValidationTraitTest extends \PHPUnit_Framework_TestCase {
 		$expectedBar->validate();
 	}
 
+	public function testValidationExceptionContent() {
+
+		// given
+		$validationErrorMessageName = 'This value should be equal to "foo".';
+		$validationErrorMessageOtherName = 'This value should be equal to "bar".';
+
+		$expectedBar = (new Bar("invalid", null))->setOtherName("invalid");
+
+		// when
+		try {
+			$expectedBar->validate();
+			$this->fail("expected exception, shouldn't be here");
+		} catch (ValidationException $e) {
+			$this->assertContains($validationErrorMessageName, $e->getMessage());
+			$this->assertContains($validationErrorMessageOtherName, $e->getMessage());
+			$this->assertEquals($validationErrorMessageName, $e->getConstraintViolationList()->get(0)->getMessage());
+			$this->assertEquals($validationErrorMessageOtherName, $e->getConstraintViolationList()->get(1)->getMessage());
+		}
+	}
+
 }


### PR DESCRIPTION
- updating ValidationException to better manage constraint violations (rather than a debut getMessage() only)
- updating Entity to expose it (Throws ValidationException rather than swallowing it and throwing a sanitized BadRequestException instead)
- updating ValidationException to extend BadRequestException for backwards compatibility (Entity used to throw a vanilla BadRequestException on validation error)